### PR TITLE
[GSCC-6420] - Update thor gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    foreman (0.82.0)
-      thor (~> 0.19.1)
+    foreman (0.83.0)
+      thor (~> 0.20.3)
 
 GEM
   remote: http://rubygems.org/
@@ -11,22 +11,20 @@ GEM
       builder
       mime-types
       xml-simple
-    builder (3.2.2)
-    codeclimate-test-reporter (0.5.0)
-      simplecov (>= 0.7.1, < 1.0.0)
-    diff-lcs (1.2.5)
-    docile (1.1.5)
+    builder (3.2.4)
+    codeclimate-test-reporter (1.0.7)
+      simplecov
+    diff-lcs (1.3)
+    docile (1.3.2)
     fakefs (0.4.3)
     hpricot (0.8.6)
     hpricot (0.8.6-java)
-    json (1.8.3)
-    json (1.8.3-java)
-    mime-types (3.0)
+    mime-types (3.3.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0221)
-    mustache (1.0.3)
-    rake (11.1.2)
-    rdiscount (2.1.8)
+    mime-types-data (3.2019.1009)
+    mustache (1.1.1)
+    rake (13.0.1)
+    rdiscount (2.2.0.1)
     ronn (0.7.3)
       hpricot (>= 0.8.2)
       mustache (>= 0.7.0)
@@ -40,15 +38,14 @@ GEM
     rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.99.4)
-    simplecov (0.11.2)
-      docile (~> 1.1.0)
-      json (~> 1.8)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.0)
-    thor (0.19.1)
-    timecop (0.8.1)
+    simplecov (0.18.5)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
+    thor (0.20.3)
+    timecop (0.9.1)
     xml-simple (1.1.5)
-    yard (0.8.7.6)
+    yard (0.9.24)
 
 PLATFORMS
   java
@@ -69,4 +66,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.17.3

--- a/foreman.gemspec
+++ b/foreman.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
   gem.files = Dir["**/*"].select { |d| d =~ %r{^(README|bin/|data/|ext/|lib/|spec/|test/)} }
   gem.files << "man/foreman.1"
 
-  gem.add_dependency 'thor', '~> 0.19.1'
+  gem.add_dependency 'thor', '~> 0.20.3'
 end

--- a/lib/foreman/version.rb
+++ b/lib/foreman/version.rb
@@ -1,5 +1,5 @@
 module Foreman
 
-  VERSION = "0.82.0"
+  VERSION = "0.83.0"
 
 end


### PR DESCRIPTION
- Update thor gem, there is a dependency on hydepark to upgrade to Rails 6
- Bump to version: 0.83